### PR TITLE
Add dockercfg secret

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,10 @@ ENV OPERATOR=/usr/local/bin/heimdall \
 COPY build/_output/bin/heimdall ${OPERATOR}
 
 COPY build/bin /usr/local/bin
-RUN  /usr/local/bin/user_setup
+
+RUN /usr/local/bin/user_setup \
+    && mkdir -p /usr/local/docker \
+    && ln -sf /tmp/docker/.dockerconfigjson /usr/local/docker/config.json
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/deploy/dockercfg_secret.yaml
+++ b/deploy/dockercfg_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: xxxxxxx-pull-secret
+data:
+  .dockerconfigjson: xxxxxxx
+type: kubernetes.io/dockerconfigjson

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,6 +31,8 @@ spec:
             periodSeconds: 10
             failureThreshold: 1
           env:
+            - name: DOCKER_CONFIG
+              value: "/usr/local/docker"
             - name: WATCH_NAMESPACE
               value: ""
             - name: POD_NAME
@@ -39,3 +41,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "heimdall"
+          volumeMounts:
+            - mountPath: /tmp/docker
+              name: heimdall-dockercfg
+      volumes:
+        - name: heimdall-dockercfg
+          secret:
+            secretName: heimdall-dockercfg


### PR DESCRIPTION
Adds the ability to mount a kubernetes.io/dockerconfigjson secret into the operator container and have it used by the normal docker keychain authentication by linking it to /usr/local/docker/config.json and setting the DOCKER_CONFIG to point to that directory.

ToDo:

* Need to figure out how this will work in testing