### PR TITLE
default recheck time every 24 hours

### DIFF
--- a/pkg/domain/types.go
+++ b/pkg/domain/types.go
@@ -120,5 +120,5 @@ const (
 	HeimdallLastChecked    = "heimdall.lastcheck"
 	HeimdallImagesChecked  = "heimdall.imageschecked"
 	TimeFormat             = time.RFC822Z
-	MinRecheckIntervalMins = 30
+	MinRecheckIntervalMins = 24 * 60
 )


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/INTLY-4917

**What**
Set default time for heimdall checks every 24 hours.

**Verification**
Check here https://prometheus-route-middleware-monitoring.apps.lfitzger-3531.open.redhat.com/graph?g0.range_input=1h&g0.expr=heimdall_registry_calls_total&g0.tab=0 in 24 hours. 
Contact me for creds