### PR TITLE
fix error on namespace on service creation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -63,6 +63,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		log.Error(err, "failed to get operator namespace")
+		os.Exit(1)
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -122,7 +128,7 @@ func main() {
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, watchNamespace, services, addMonitoringKeyLabelToOperatorServiceMonitor)
+	_, err = metrics.CreateServiceMonitors(cfg, operatorNamespace, services, addMonitoringKeyLabelToOperatorServiceMonitor)
 	if err != nil {
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return


### PR DESCRIPTION
Fixing an error that was missed in https://github.com/integr8ly/heimdall/pull/22
Error on empty namespace as the WatchNamspace is set to "". Namespace cannot be empty for ServiceMonitor creation.
It's deployed here https://master.lfitzger-3531.open.redhat.com/console/project/heimdall/overview