### PR TITLE
INTLY-5489 CLI to check all namespaces when flag is not present

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/integr8ly/heimdall/pkg/cluster"
 	"github.com/integr8ly/heimdall/pkg/controller/deploymentconfigs"
 	"github.com/integr8ly/heimdall/pkg/controller/deployments"
@@ -9,14 +14,12 @@ import (
 	"github.com/integr8ly/heimdall/pkg/registry"
 	"github.com/integr8ly/heimdall/pkg/rhcc"
 	"github.com/jedib0t/go-pretty/table"
-	"github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	v1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	imagesv1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"log"
-	"os"
 	client2 "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"strings"
 )
 
 func main() {
@@ -45,7 +48,10 @@ func main() {
 	dcReport := deploymentconfigs.NewReport(clusterIS, registryIS, dcClient)
 	deploymentReport := deployments.NewReport(clusterIS, registryIS, client.AppsV1())
 	var reports []domain.ReportResult
-	namespaces := strings.Split(*namespacePtr, ",")
+	namespaces, err := getNamespaces(client, namespacePtr)
+	if err != nil {
+		log.Fatalf("error getting namespaces: %v", err)
+	}
 	for _, n := range namespaces {
 
 		dcReports, err := dcReport.Generate(n, *componentPtr)
@@ -94,4 +100,26 @@ func main() {
 		t.Render()
 		//time.Sleep(time.Minute * 3)
 	}
+}
+
+// getNamespaces obtains a slice of namespaces to inspect based on the presence
+// and contents of the `namespaceFlag` passed as a command argument
+func getNamespaces(client *kubernetes.Clientset, namespaceFlag *string) ([]string, error) {
+	if namespaceFlag != nil && *namespaceFlag != "" {
+		return strings.Split(*namespaceFlag, ","), nil
+	}
+
+	log.Println("generating report for all namespaces")
+
+	namespaceList, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error querying namespaces: %w", err)
+	}
+
+	result := make([]string, len(namespaceList.Items))
+	for i, ns := range namespaceList.Items {
+		result[i] = ns.Name
+	}
+
+	return result, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
+	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/cluster/images.go
+++ b/pkg/cluster/images.go
@@ -2,6 +2,9 @@ package cluster
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/integr8ly/heimdall/pkg/domain"
 	v12 "github.com/openshift/api/apps/v1"
 	v13 "github.com/openshift/api/image/v1"
@@ -9,9 +12,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"regexp"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strings"
 )
 
 var log = logf.Log.WithName("image_service")
@@ -182,7 +183,8 @@ func ParseImage(i string) *domain.ClusterImage {
 	registryURLParts := strings.Split(si, "/")
 	imageParts := strings.Split(registryURLParts[len(registryURLParts)-1], ":")
 	registryURL := strings.Join(registryURLParts[:len(registryURLParts)-1], "/") + "/" + imageParts[0]
-	imagePath := strings.Split(strings.Split(si, ":")[0], "/")
+	imagePath := strings.Split(si, "/")
+	imagePath[2] = strings.Split(imagePath[2], ":")[0] // remove the tag from the last part
 	if len(imageParts) == 1 {
 		imageParts = append(imageParts, "latest")
 	}


### PR DESCRIPTION
> [Link to JIRA](https://issues.redhat.com/browse/INTLY-5489)

Add logic in CLI to get a report for all namespaces in the cluster when the `-namespaces` flag is not present in the command argument.