### PR TITLE
INTLY-5492 Include stateful sets

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -24,6 +24,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - '*'
 - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -26,6 +26,7 @@ rules:
   resources:
   - replicasets
   - deployments
+  - statefulsets
   - deployments/finalizers
   verbs:
   - '*'

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/brancz/gojsontoyaml v0.0.0-20190425155809-e8bd32d46b3d/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=
@@ -107,6 +108,7 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/docker/distribution v0.0.0-20170726174610-edc3ab29cdff/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v0.7.3-0.20190409004836-2e1cfbca03da/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -216,6 +218,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48 h1:X+zN6RZXsvnrSJaAIQhZezPfAfvsqihKKR8oiLHid34=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -420,7 +423,9 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634 h1:BNgUWy7fCNMkfpyG05/9wWeDnIY4hqs9UpqkGIjAb68=
 github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -429,6 +434,7 @@ github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible h1:q2
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a h1:2t89qt9TR5koRb55cdTMM3NOMP238eHNeUnZ7uihHSA=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
+github.com/openshift/origin v0.0.0-20160503220234-8f127d736703 h1:KLVRXtjLhZHVtrcdnuefaI2Bf182EEiTfEVDHokoyng=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
@@ -805,6 +811,7 @@ k8s.io/kubelet v0.0.0-20190918202550-958285cf3eef/go.mod h1:y3faEeGRJ9L54/YJWIF0
 k8s.io/kubernetes v1.11.7-beta.0.0.20181219023948-b875d52ea96d/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.14.2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.15.4 h1:ykcH+DoCr9wYjYfHvd2xU0HoSo/Y9m4+/0+zHqkYjbw=
 k8s.io/kubernetes v1.15.4/go.mod h1:4Ggyo4AFgjbIzULOminzUJAvgbzY3j5ysXlW/a0PdcQ=
 k8s.io/legacy-cloud-providers v0.0.0-20190918203421-225f0541b3ea/go.mod h1:qd7ZEaONgkMZRdUbaoK6ngxjuJz8kLBImMukwL7mOIg=
 k8s.io/metrics v0.0.0-20190918202012-3c1ca76f5bda/go.mod h1:LxAN6ulYLPVQGTtRkXEUyylgseTWArq1iCZ9Zve8edc=

--- a/pkg/controller/add_resources.go
+++ b/pkg/controller/add_resources.go
@@ -4,6 +4,7 @@ import (
 	"github.com/integr8ly/heimdall/pkg/controller/deploymentconfigs"
 	"github.com/integr8ly/heimdall/pkg/controller/deployments"
 	"github.com/integr8ly/heimdall/pkg/controller/imagemonitor"
+	"github.com/integr8ly/heimdall/pkg/controller/statefulset"
 )
 
 func init() {
@@ -11,4 +12,5 @@ func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs, deploymentconfigs.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, deployments.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, imagemonitor.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, statefulset.Add)
 }

--- a/pkg/controller/generic/generic_controller.go
+++ b/pkg/controller/generic/generic_controller.go
@@ -1,0 +1,168 @@
+package generic
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/integr8ly/heimdall/pkg/cluster"
+	"github.com/integr8ly/heimdall/pkg/controller/validation"
+	"github.com/integr8ly/heimdall/pkg/domain"
+	"github.com/integr8ly/heimdall/pkg/registry"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type logger interface {
+	Error(err error, msg string, keysAndValues ...interface{})
+	Info(msg string, keysAndValues ...interface{})
+}
+
+// MakeGenericReconciler creates a generic reconciler that delegates the object
+// access to an impl HeimdallObjectInterface
+func MakeGenericReconciler(
+	requeueInterval time.Duration,
+	resourceName string,
+	log logger,
+	podService *cluster.Pods,
+	clusterImageService *cluster.ImageService,
+	registryImageService *registry.ImageService,
+	impl HeimdallObjectInterface,
+) *Reconciler {
+	return &Reconciler{
+		HeimdallObjectInterface: impl,
+
+		requeueInterval: requeueInterval,
+		resourceName:    resourceName,
+		log:             log,
+		reportService: &Reports{
+			HeimdallObjectInterface: impl,
+			resourceName:            resourceName,
+			clusterImageService:     clusterImageService,
+			registryImageService:    registryImageService,
+		},
+		podService: podService,
+	}
+}
+
+// Reconciler is a generic implementation of a reconciler that delegates
+// the object access logic to a HeimdallObjectInterface to check the object's
+// images and label its pods
+type Reconciler struct {
+	HeimdallObjectInterface
+
+	requeueInterval time.Duration
+	resourceName    string
+	log             logger
+
+	reportService *Reports
+	podService    *cluster.Pods
+}
+
+// HeimdallObjectInterface knows how to access resources watched by Heimdall
+type HeimdallObjectInterface interface {
+	GetObject(namespace, name string) (v1.Object, error)
+	UpdateObject(v1.Object) error
+	ListObjects(namespace string) ([]v1.Object, error)
+	GetPodTemplateLabels(obj v1.Object) map[string]string
+}
+
+// Reconcile checks the images of an object managed by r's HeimdallObjectInterface
+// and labels the pods accordingly
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	obj, err := r.GetObject(request.Namespace, request.Name)
+	if err != nil {
+		r.log.Error(err, fmt.Sprintf("failed to get %s in namespace %s with name %s",
+			r.resourceName, request.Name, request.Namespace))
+		return reconcile.Result{}, err
+	}
+
+	if _, ok := obj.GetLabels()[domain.HeimdallMonitored]; !ok {
+		return reconcile.Result{}, nil
+	}
+
+	images, err := r.reportService.GetImages(obj)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	should, err := validation.ShouldCheck(obj, images)
+	if err != nil && validation.IsParseErr(err) {
+		delete(obj.GetAnnotations(), domain.HeimdallImagesChecked)
+		if err := r.UpdateObject(obj); err != nil {
+			r.log.Error(err, fmt.Sprintf(" failed to label %s %s/%s",
+				r.resourceName,
+				request.Namespace,
+				request.Name,
+			))
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	if !should {
+		r.log.Info(fmt.Sprintf("criteria for re checking %s no met", request.Name))
+		return reconcile.Result{}, nil
+	}
+
+	r.log.Info(fmt.Sprintf("%s %s in namespace %s is being monitored by heimdall",
+		r.resourceName,
+		request.Name,
+		request.Namespace,
+	))
+
+	report, err := r.reportService.Generate(request.Namespace, request.Name)
+	if err != nil {
+		r.log.Error(err, "failed to generate a report for images in %s %s in namespace %s",
+			r.resourceName,
+			request.Name,
+			request.Namespace,
+		)
+		return reconcile.Result{RequeueAfter: r.requeueInterval}, nil
+	}
+
+	r.log.Info(fmt.Sprintf("generated reports for %s", r.resourceName),
+		"reports", len(report),
+		"namespace", request.Namespace,
+		"name", request.Name,
+	)
+
+	obj, err = r.GetObject(request.Namespace, request.Name)
+	if err != nil {
+		r.log.Info(fmt.Sprintf("failed to get %s in namespace %s with name %s",
+			r.resourceName,
+			request.Namespace,
+			request.Name,
+		))
+		return reconcile.Result{}, nil
+	}
+
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(map[string]string{})
+	}
+	annotations := obj.GetAnnotations()
+
+	checked := []string{}
+	for _, rep := range report {
+		checked = append(checked, rep.ClusterImage.SHA256Path)
+		if err := r.podService.LabelPods(&rep); err != nil {
+			r.log.Error(err, "failed to label pod, will retry as soon as possible")
+			return reconcile.Result{}, nil
+		}
+	}
+
+	annotations[domain.HeimdallLastChecked] = time.Now().Format(domain.TimeFormat)
+	annotations[domain.HeimdallImagesChecked] = strings.Join(checked, ",")
+
+	if err := r.UpdateObject(obj); err != nil {
+		r.log.Error(err, fmt.Sprintf("failed to annotate %s %s %s",
+			r.resourceName,
+			request.Namespace,
+			request.Name,
+		))
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{RequeueAfter: r.requeueInterval}, nil
+}

--- a/pkg/controller/generic/report.go
+++ b/pkg/controller/generic/report.go
@@ -1,0 +1,117 @@
+package generic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/integr8ly/heimdall/pkg/cluster"
+	"github.com/integr8ly/heimdall/pkg/domain"
+	"github.com/integr8ly/heimdall/pkg/registry"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Reports contains the generic logic to create reports for the images of objects
+// managed by its HeimdallObjectInterface implementation
+type Reports struct {
+	HeimdallObjectInterface
+
+	clusterImageService  *cluster.ImageService
+	registryImageService *registry.ImageService
+
+	resourceName string
+}
+
+// MakeGenericReports creates a Reports for a resource with resourceName that's
+// access is managed by impl
+func MakeGenericReports(
+	impl HeimdallObjectInterface,
+	clusterImageService *cluster.ImageService,
+	registryImageService *registry.ImageService,
+	resourceName string,
+) *Reports {
+	return &Reports{
+		HeimdallObjectInterface: impl,
+		clusterImageService:     clusterImageService,
+		registryImageService:    registryImageService,
+		resourceName:            resourceName,
+	}
+}
+
+// GetImages gets a list of images used by obj
+func (r *Reports) GetImages(obj v1.Object) ([]*domain.ClusterImage, error) {
+	images, err := r.clusterImageService.FindImagesFromLabels(
+		obj.GetNamespace(),
+		r.GetPodTemplateLabels(obj),
+	)
+	if err == nil {
+		return images, nil
+	}
+
+	return nil, errors.Wrapf(
+		err,
+		"failed to get images for %s in namespace %s",
+		r.resourceName,
+		obj.GetNamespace(),
+	)
+}
+
+// Generate generates a report for an object with a given name and namespace,
+// delegating the object access logic to r's HeimdallObjectInterface
+func (r *Reports) Generate(namespace, name string) ([]domain.ReportResult, error) {
+	var reports []domain.ReportResult
+	var objects []v1.Object
+	checked := map[string]domain.ReportResult{}
+
+	if name == "*" {
+		objectsList, err := r.ListObjects(namespace)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list %s objects in namespace %s",
+				r.resourceName,
+				namespace,
+			)
+		}
+		objects = objectsList
+	} else {
+		object, err := r.GetObject(namespace, name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get %s %s in namespace %s",
+				r.resourceName,
+				name,
+				namespace,
+			)
+		}
+		objects = []v1.Object{object}
+	}
+
+	for _, obj := range objects {
+		images, err := r.GetImages(obj)
+		if err != nil {
+			fmt.Print("error finding images", err)
+		}
+
+		for _, i := range images {
+			if !strings.Contains(i.FullPath, "redhat") {
+				continue
+			}
+
+			if rep, ok := checked[i.SHA256Path]; ok {
+				rep.Component = obj.GetName()
+				reports = append(reports, rep)
+				continue
+			}
+
+			result, err := r.registryImageService.Check(i)
+			if err != nil {
+				fmt.Println(err, "a report failed ")
+			} else {
+				result.Component = obj.GetName()
+				reports = append(reports, result)
+			}
+
+			checked[i.FullPath] = result
+		}
+	}
+
+	return reports, nil
+}

--- a/pkg/controller/imagemonitor/controller.go
+++ b/pkg/controller/imagemonitor/controller.go
@@ -2,6 +2,7 @@ package imagemonitor
 
 import (
 	"context"
+
 	"github.com/integr8ly/heimdall/pkg/apis/imagemonitor/v1alpha1"
 	"github.com/integr8ly/heimdall/pkg/cluster"
 	"github.com/integr8ly/heimdall/pkg/domain"
@@ -104,7 +105,7 @@ func (r *ReconcileImageMonitor) Reconcile(request reconcile.Request) (reconcile.
 	}
 	log.Info("have image monitor for namespace " + imageMon.Namespace + " with name " + imageMon.Name)
 	// find deployment configs and deployments that match in the namespace and label them
-	if err := r.objectLabeler.LabelAllDeploymentsAndDeploymentConfigs(ctx, map[string]string{domain.HeimdallMonitored: "true"}, imageMon.Spec.ExcludePattern, imageMon.Namespace); err != nil {
+	if err := r.objectLabeler.LabelObjects(ctx, map[string]string{domain.HeimdallMonitored: "true"}, imageMon.Spec.ExcludePattern, imageMon.Namespace); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/statefulset/report.go
+++ b/pkg/controller/statefulset/report.go
@@ -1,0 +1,18 @@
+package statefulset
+
+import (
+	"github.com/integr8ly/heimdall/pkg/cluster"
+	"github.com/integr8ly/heimdall/pkg/controller/generic"
+	"github.com/integr8ly/heimdall/pkg/registry"
+	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+)
+
+// NewReport creates a generic.Reports that generates reports for stateful sets
+func NewReport(clusterImageService *cluster.ImageService, registryImageService *registry.ImageService, client v1.AppsV1Interface) *generic.Reports {
+	return generic.MakeGenericReports(
+		&objectInterface{client},
+		clusterImageService,
+		registryImageService,
+		"stateful set",
+	)
+}

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -1,0 +1,116 @@
+package statefulset
+
+import (
+	"time"
+
+	"github.com/integr8ly/heimdall/pkg/cluster"
+	"github.com/integr8ly/heimdall/pkg/controller/generic"
+	"github.com/integr8ly/heimdall/pkg/registry"
+	"github.com/integr8ly/heimdall/pkg/rhcc"
+	imagesv1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"github.com/pkg/errors"
+	v12 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_statefulset")
+
+const labelFormat = "heimdall.%s"
+
+const requeueInterval = time.Hour * 4
+
+// Add creates a new StatefulSet Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	client, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return errors.Wrap(err, "failed to create k8s client")
+	}
+
+	isClient, err := imagesv1.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return errors.Wrap(err, "failed to create images client")
+	}
+
+	return add(mgr, newReconciler(mgr, client, isClient))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, client kubernetes.Interface, isClient *imagesv1.ImageV1Client) reconcile.Reconciler {
+	clusterImageService := cluster.NewImageService(client, isClient)
+	registryImageService := registry.NewImagesService(&registry.Client{}, &rhcc.Client{}, &rhcc.Client{})
+
+	impl := &objectInterface{
+		client: client.AppsV1(),
+	}
+
+	return generic.MakeGenericReconciler(
+		requeueInterval,
+		"stateful set",
+		log,
+		cluster.NewPods(mgr.GetClient()),
+		clusterImageService,
+		registryImageService,
+		impl,
+	)
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("statefulset-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource StatefulSet
+	return c.Watch(&source.Kind{Type: &v12.StatefulSet{}}, &handler.EnqueueRequestForObject{})
+}
+
+// blank assignment to verify that ReconcileStatefulSet implements HeimdallObjectInterface
+var _ generic.HeimdallObjectInterface = &objectInterface{}
+
+// objectInterface is an implementation of generic.HeimdallObjectInterface
+// that knows how to access stateful sets
+type objectInterface struct {
+	client v1.AppsV1Interface
+}
+
+// ListObjects gets the stateful sets in namespace as v1.Object types
+func (r *objectInterface) ListObjects(namespace string) ([]metav1.Object, error) {
+	statefulSets, err := r.client.StatefulSets(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]metav1.Object, len(statefulSets.Items))
+	for i, s := range statefulSets.Items {
+		result[i] = &s
+	}
+
+	return result, nil
+}
+
+// GetPodTemplateLabels gets the pod template labels for a given stateful set obj
+func (r *objectInterface) GetPodTemplateLabels(obj metav1.Object) map[string]string {
+	return obj.(*v12.StatefulSet).Spec.Template.Labels
+}
+
+// GetObject gets a stateful set name in namespace
+func (r *objectInterface) GetObject(namespace, name string) (metav1.Object, error) {
+	return r.client.StatefulSets(namespace).Get(name, metav1.GetOptions{})
+}
+
+// UpdateObject updates a stateful set
+func (r *objectInterface) UpdateObject(obj metav1.Object) error {
+	_, err := r.client.StatefulSets(obj.GetNamespace()).Update(obj.(*v12.StatefulSet))
+	return err
+}


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/INTLY-5492

Create a new controller that watches StatefulSet objects and inspects their images.
Update CLI to generate reports for stateful sets as well.

Factor common logic between controllers into a generic reconciler `pkg/controller/generic`
that performs the reconcilliation logic delegating the specific logic for each resource
into an injected `HeimdallObjectInterface` implementation.

# Verification steps

You'll need a cluster with RHMI 2.x installation. The Keycloak operator uses stateful sets to deploy the Keycloak pods. The following steps use keycloak to verify this

## CLI

1. Build the CLI as specified in the [README](https://github.com/integr8ly/heimdall/blob/master/README.md)
2. Generate a report for the RHSSO namespace:
```
./cli -namespaces=redhat-rhmi-rhsso
```
3. Verify that the keycloak docker image is shown in the resulting report `redhat-sso-7/sso73-openshift`

## Cluster

1. Manually deploy the Heimdall operator
```
oc login...

# prepare cluster
make cluster/prepare

# switch to project
oc project heimdall

# deploy cluster role and cluster role binding
oc create -f deploy/cluster_role.yaml
oc create -f deploy/cluster_role_binding.yaml

# create pull secret - ping for pull secret if required

# update operator deployment to use quay.io/sfrancog/heimdall-operator:master image and pull secret created in previous step
vi ./deploy/operator.yaml

# deploy operator
oc create -f ./deploy/operator.yaml 
```
2. Once the operator is running, find the Keycloak StatefulSet and add the label `heimdall.monitored: 'true'` to indicate Heimdall to monitor the StatefulSet
3. Verify that the StatefulSet is annotated with the `heimdall.*` annotations
4. Find the keycloak stateful set pods and verify that `heimdall.*` labels have been added to them

### ImageMonitor verification

1. Delete the `heimdall.monitored` label from the StatefulSet and verify that the annotations are removed.
2. In the same namespace, create an ImageMonitor CR with empty spec (it'll monitor all resources in the namespace)
3. Verify that the `heimdall.monitored` label is added to the StatefulSet
4. Delete the ImageMonitor
5. Verify that the `heimdall.monitored` label is deleted automatically